### PR TITLE
Add `noImplicitOverride` flag 

### DIFF
--- a/src/CryptoOutput.ts
+++ b/src/CryptoOutput.ts
@@ -52,7 +52,7 @@ export class CryptoOutput extends RegistryItem {
     }
   };
 
-  public toString = () => {
+  public override toString = () => {
     return this._toOutputDescriptor(0);
   };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "noImplicitReturns": true,
     "noImplicitAny": false,
     "noImplicitThis": false,
+    "noImplicitOverride": true,
     "strictNullChecks": false,
     "removeComments": true,
     "outDir": "./dist"


### PR DESCRIPTION
The flag `noImplictOverride` has been set, ensuring that the `override` keyword is used whenever a subclass overrides a field/method from a parent class. This ensures this library remains compatible with projects that use this flag.

The `override` keyword was only needed in one place.

Fixes https://github.com/KeystoneHQ/ur-registry/issues/17