### PR TITLE
Build release task

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "lint": "eslint . --ext .ts,.tsx",
     "test": "jest --coverage",
     "test:watch": "jest --watch",
-    "build:purescript": "webpack --config webpack.config.js"
+    "build:purescript": "webpack --config webpack.config.js",
+    "build:release": "yarn run clean && yarn run build && yarn run build:purescript"
   },
   "author": "Soralit <soralitria@gmail.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
Adds a separate task to build the files for a release, because not all versions seem to contain urlib.min.js